### PR TITLE
feat(zico): capability-aware foundation — intent schema, discovery tool, contract doc (#66, #69, #70)

### DIFF
--- a/new_zico/docs/agent-capability-contract.md
+++ b/new_zico/docs/agent-capability-contract.md
@@ -1,0 +1,114 @@
+# Agent ↔ Capability Contract
+
+> Vocabulário oficial para todo agente Zico que dispara ações no Panorama backend. Pareia com o `@panorama/capability` shared package (cards Hugo #199–#210) e com os schemas/tools introduzidos nos cards Rizzi #69–#70.
+
+**Audiência:** quem escreve prompts, ferramentas LangChain, ou novos agentes em `zico_agents/new_zico/src/agents/`.
+
+---
+
+## 1. Por que este contrato existe
+
+Antes da refatoração, prompts de agente mencionavam protocolos diretamente — "I'll swap your USDC using Uniswap", "stake on Lido", "borrow from Benqi". Isso prendia o agente a nomes que o backend reescolhe em runtime e quebrava sempre que um provider entrava ou saía do registry.
+
+A partir do Bloco 5 (lending/staking/liquidity migradas) o backend fala **capability**, não protocolo. O agente precisa fazer o mesmo:
+
+- **User-facing text:** só fala capability (`"swap"`, `"liquidity pool"`, `"stake"`)
+- **Tool calls:** emitem `CapabilityIntent`, não payload livre
+- **Decisões:** consultam `/v1/capability/_discovery` antes de propor ação
+
+---
+
+## 2. Pipeline de tradução NL → Capability Call
+
+```
+┌────────────┐    ┌──────────┐    ┌──────────────────┐    ┌──────────┐
+│  user NL   │───▶│  agent   │───▶│ CapabilityIntent │───▶│ backend  │
+│  "swap     │    │ classify │    │ {capability,     │    │ POST     │
+│   ETH USDC"│    │   +      │    │  action, payload,│    │ /v1/cap  │
+└────────────┘    │ discover │    │  chain_id, ...}  │    └──────────┘
+                  └──────────┘    └──────────────────┘
+```
+
+**Etapas que o agente DEVE seguir, nessa ordem:**
+
+1. **Parse intent.** Classifica a NL em `(capability, action)`. Exemplos:
+   - "swap 1 ETH for USDC" → `("swap", "prepare-swap")`
+   - "add liquidity to ETH/USDC pool" → `("liquidity", "prepare-add")`
+   - "stake my ETH" → `("staking", "prepare-stake")`
+2. **Discovery.** Chama o tool `discover_capabilities` (card #69) passando o `chain_id` que o usuário está usando. Se a capability não está no snapshot OU não tem provider `healthy: true` naquele chain, o agente **não propõe a ação** — explica a indisponibilidade ao user.
+3. **Build payload.** Monta o `payload` específico da action (formatos típicos: `tokenIn/tokenOut/amountIn` para swap, `poolId/amountA/amountB` para liquidity, `amount` para staking).
+4. **Emit intent.** Constrói um `CapabilityIntent` (`src/models/capability_intent.py`, card #70) com `tenant_id`, `trace_id` herdados do contexto da conversa.
+5. **Dispatch.** Dispatcher HTTP usa `intent.endpoint_path()` + `intent.to_capability_request()` para fazer `POST /v1/capability/<cap>/<action>` com o envelope camelCase que Hugo definiu.
+
+---
+
+## 3. Regras de output (HARD)
+
+| Regra | Faça | Não faça |
+|---|---|---|
+| Vocabulário | "I'll prepare a swap for you" | "I'll use Uniswap to swap" |
+| Recomendação | "swap is available on Base" | "Aerodrome is the best DEX on Base" |
+| Falha de provider | "swap is temporarily unavailable on Base" | "Uniswap returned 503" |
+| Routing/seleção | "the backend will pick the best route" | "I'll route through Multihop" |
+
+**Por que:** o backend pode rolar providers de um sprint pro outro. Se o agente mencionar `aerodrome` num prompt cacheado e o registry trocar pra `uniswap` na semana seguinte, o agente vira mentiroso.
+
+**Exceção autorizada:** explicações técnicas explícitas em modo debug/dev (`DEBUG=true`). Nunca em conversa de produção.
+
+---
+
+## 4. Tradução de erros — `ErrorCategory` → mensagem human-friendly
+
+O backend retorna `CapabilityErrorResponse` com `error.category` (enum fechado). O agente traduz pra prosa antes de mostrar ao user.
+
+| `category` | Mensagem sugerida ao user |
+|---|---|
+| `VALIDATION` | "I had trouble understanding the request — could you confirm the token and amount?" |
+| `UNSUPPORTED_ROUTE` | "This swap isn't supported on `<chain>` — the pair may not exist there yet." |
+| `INSUFFICIENT_LIQUIDITY` | "Not enough liquidity on-chain for that amount right now. Want to try a smaller size?" |
+| `RATE_LIMITED` | "We're hitting upstream limits — please try again in a few seconds." |
+| `PROVIDER_FAILURE` | "The on-chain provider failed and we couldn't fall back. I'll retry once and let you know." |
+| `UNAVAILABLE` | "That capability is offline on `<chain>` right now. I'll let you know when it's back." |
+| `INTERNAL` | "Something went wrong on our side — engineering has been notified." |
+
+**Nunca** vaze stack traces, IDs de provider ou status codes HTTP no output user-facing. Esses ficam no `metadata.error` que vai pro log estruturado.
+
+---
+
+## 5. Onde está cada peça
+
+| Peça | Arquivo | Card |
+|---|---|---|
+| `CapabilityIntent` schema | `src/models/capability_intent.py` | #70 |
+| `discover_capabilities` tool | `src/integrations/panorama_gateway/capability_discovery.py` | #69 |
+| Lista canônica de capability slugs | `panorama-block-backend/shared/capability/provider.types.ts` (`CAPABILITY_SLUGS`) | Hugo #200 |
+| `CapabilityRequest<T>` envelope (wire) | `panorama-block-backend/shared/capability/envelope.types.ts` | Hugo #199 |
+| Discovery handler | `panorama-block-backend/shared/capability/http/discovery.handler.ts` | Hugo #207 |
+| `ErrorCategory` enum | `panorama-block-backend/shared/capability/errors.ts` | Hugo #201 |
+
+---
+
+## 6. Roteiro pra novos agents
+
+Quando criar um novo agente que vai disparar ações:
+
+1. Registre `discover_capabilities_tool` na lista de tools do agente.
+2. Force o agente a chamar discovery antes de propor qualquer prepare-*.
+3. Final step do agent SEMPRE retorna um `CapabilityIntent` (ou `None` se a capability não estiver disponível).
+4. Escreva contract tests (modelo no card #71) que dado uma NL específica, assertam que o output:
+   - Não contém nome de protocolo (`grep` por `uniswap|aerodrome|lido|benqi|moonwell` no output text)
+   - É um `CapabilityIntent` válido pelo schema Pydantic
+   - `(capability, action)` aparecem em algum cenário válido do discovery mock
+
+---
+
+## 7. FAQ
+
+**Pode mencionar "DCA" se a capability é `automation`?**
+Sim. "DCA", "limit order", "recurring buy" são *features* user-facing dentro da capability `automation`. O slug interno (`automation`) é detalhe de implementação que não precisa vazar.
+
+**E se o discovery falhar (BE down)?**
+O tool retorna `{ capabilities: [], error: "..." }` — o agente trata como "nada disponível" e pede pro user tentar de novo em alguns segundos. Não inventa providers.
+
+**Como descobrir qual `action` usar?**
+Cada capability tem um conjunto fechado de actions documentado nos docs específicos: `swap-capability.md`, `liquidity-capability.md`, `staking-capability.md` (em `panorama-block-backend/<svc>/docs/`). Esses são autoridade — quando bater na ambiguidade, leia o doc da capability.

--- a/new_zico/src/integrations/panorama_gateway/capability_discovery.py
+++ b/new_zico/src/integrations/panorama_gateway/capability_discovery.py
@@ -1,0 +1,232 @@
+"""Capability availability lookup (card #69).
+
+Wraps the backend `GET /v1/capability/_discovery` endpoint owned by the
+`@panorama/capability` shared package (card #207). Returns the discovery
+snapshot that agents should consult **before** proposing a state-mutating
+action — so they only ever suggest capabilities the BE confirms are healthy.
+
+The endpoint response shape (`AvailabilityMap`) is defined in
+`shared/capability/availability.types.ts`.
+
+A 30-second in-process cache is layered on top to keep token cost low when
+several agents fan out within the same turn. The TTL matches the
+`cacheTtlSeconds` the BE handler announces.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional
+
+import httpx
+from langchain_core.tools import tool
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Module-level cache
+# ---------------------------------------------------------------------------
+
+
+_CACHE_TTL_SECONDS = 30
+_cache_lock = threading.Lock()
+_cache: Dict[Optional[int], "_CacheEntry"] = {}
+
+
+class _CacheEntry:
+    __slots__ = ("payload", "expires_at")
+
+    def __init__(self, payload: Dict[str, Any], ttl_seconds: float) -> None:
+        self.payload = payload
+        self.expires_at = time.monotonic() + ttl_seconds
+
+
+def _cached(chain_id: Optional[int]) -> Optional[Dict[str, Any]]:
+    with _cache_lock:
+        entry = _cache.get(chain_id)
+        if entry is None or entry.expires_at <= time.monotonic():
+            return None
+        return entry.payload
+
+
+def _store(chain_id: Optional[int], payload: Dict[str, Any], ttl_seconds: float) -> None:
+    with _cache_lock:
+        _cache[chain_id] = _CacheEntry(payload, ttl_seconds)
+
+
+def clear_cache() -> None:
+    """Drop every cached discovery snapshot. Used by tests and on-demand refresh."""
+
+    with _cache_lock:
+        _cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# HTTP layer
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_TIMEOUT = 10.0
+
+
+class DiscoveryFetchError(RuntimeError):
+    """Raised when the discovery endpoint returns non-200 or unparseable JSON."""
+
+    def __init__(self, message: str, status_code: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _base_url() -> str:
+    url = os.getenv("PANORAMA_CAPABILITY_BASE_URL")
+    if not url:
+        raise RuntimeError(
+            "PANORAMA_CAPABILITY_BASE_URL is required to call /v1/capability/_discovery"
+        )
+    return url.rstrip("/")
+
+
+def _http_get_discovery(
+    chain_id: Optional[int],
+    *,
+    client: Optional[httpx.Client] = None,
+    timeout: float = _DEFAULT_TIMEOUT,
+) -> Dict[str, Any]:
+    url = f"{_base_url()}/v1/capability/_discovery"
+    params = {"chainId": str(chain_id)} if chain_id is not None else None
+
+    owns_client = client is None
+    if owns_client:
+        client = httpx.Client(timeout=timeout)
+    try:
+        response = client.get(url, params=params)
+    finally:
+        if owns_client:
+            client.close()
+
+    if response.status_code != 200:
+        raise DiscoveryFetchError(
+            f"discovery returned HTTP {response.status_code}",
+            status_code=response.status_code,
+        )
+    try:
+        body = response.json()
+    except ValueError as err:
+        raise DiscoveryFetchError("discovery response was not valid JSON") from err
+
+    # The handler wraps the AvailabilityMap in CapabilitySuccessResponse — unwrap.
+    if isinstance(body, dict) and body.get("status") == "success" and "data" in body:
+        return body["data"]
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def discover_capabilities(
+    chain_id: Optional[int] = None,
+    *,
+    force_refresh: bool = False,
+    client: Optional[httpx.Client] = None,
+) -> Dict[str, Any]:
+    """Return the discovery snapshot, hitting the cache when fresh.
+
+    Args:
+        chain_id: optional EIP-155 id; when set, the BE filters the snapshot.
+        force_refresh: bypass the in-process cache and re-hit the BE.
+        client: optional httpx.Client (used by tests; production callers omit).
+
+    Returns:
+        The `AvailabilityMap` payload as a plain dict:
+        `{ capabilities: [...], generatedAt: str, cacheTtlSeconds: int }`.
+    """
+
+    if not force_refresh:
+        cached = _cached(chain_id)
+        if cached is not None:
+            return cached
+
+    payload = _http_get_discovery(chain_id, client=client)
+
+    ttl = payload.get("cacheTtlSeconds")
+    ttl_seconds = float(ttl) if isinstance(ttl, (int, float)) and ttl > 0 else _CACHE_TTL_SECONDS
+    _store(chain_id, payload, ttl_seconds)
+    return payload
+
+
+def list_healthy_providers(
+    capability: str, chain_id: int, *, force_refresh: bool = False
+) -> List[str]:
+    """Convenience: project the discovery snapshot to provider names that report healthy."""
+
+    snapshot = discover_capabilities(chain_id=chain_id, force_refresh=force_refresh)
+    healthy: List[str] = []
+    for entry in snapshot.get("capabilities", []):
+        if entry.get("capability") != capability:
+            continue
+        by_chain = entry.get("byChain", {}) or {}
+        # AvailabilityMap.byChain keys are numeric on the wire, JSON-decoded as str.
+        providers = by_chain.get(str(chain_id), [])
+        healthy.extend(p["provider"] for p in providers if p.get("healthy"))
+    return healthy
+
+
+# ---------------------------------------------------------------------------
+# LangChain Tool wrapper — registrable on any agent
+# ---------------------------------------------------------------------------
+
+
+class DiscoverCapabilitiesInput(BaseModel):
+    """Inputs for the `discover_capabilities` LangChain tool."""
+
+    chain_id: Optional[int] = Field(
+        default=None,
+        description="Optional EIP-155 chain id (e.g. 8453 for Base). Omit for all chains.",
+    )
+    force_refresh: bool = Field(
+        default=False,
+        description="Bypass the 30-second in-process cache.",
+    )
+
+
+@tool("discover_capabilities", args_schema=DiscoverCapabilitiesInput)
+def discover_capabilities_tool(
+    chain_id: Optional[int] = None,
+    force_refresh: bool = False,
+) -> Dict[str, Any]:
+    """List capabilities (swap, lending, staking, liquidity, …) and their healthy providers.
+
+    Always call this **before** proposing a state-mutating action so you only
+    suggest capabilities the backend confirms are available on the user's chain.
+
+    Returns the raw `AvailabilityMap` so the agent can reason over per-chain
+    health, last error, and 95th-percentile latency.
+    """
+
+    try:
+        return discover_capabilities(chain_id=chain_id, force_refresh=force_refresh)
+    except DiscoveryFetchError as err:
+        logger.warning("capability discovery failed status=%s", err.status_code)
+        return {
+            "capabilities": [],
+            "generatedAt": None,
+            "cacheTtlSeconds": 0,
+            "error": str(err),
+        }
+
+
+__all__ = [
+    "DiscoveryFetchError",
+    "DiscoverCapabilitiesInput",
+    "clear_cache",
+    "discover_capabilities",
+    "discover_capabilities_tool",
+    "list_healthy_providers",
+]

--- a/new_zico/src/models/capability_intent.py
+++ b/new_zico/src/models/capability_intent.py
@@ -1,0 +1,108 @@
+"""CapabilityIntent — agent → backend capability call schema.
+
+Every Zico agent that proposes a state-mutating action emits a `CapabilityIntent`.
+The intent maps 1:1 to the backend `CapabilityRequest<T>` envelope owned by the
+`@panorama/capability` shared package (cards #199-#203). Extra fields `capability`
+and `action` identify the target endpoint `/v1/capability/<capability>/<action>`;
+they live in the URL on the wire and are stripped by `to_capability_request()`.
+
+See `docs/agent-capability-contract.md` for the surrounding contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# Closed set mirroring shared/capability/provider.types.ts CAPABILITY_SLUGS.
+# Update both sides together when adding a new capability.
+CapabilitySlug = Literal[
+    "swap",
+    "lending",
+    "staking",
+    "liquidity",
+    "bridge",
+    "automation",
+    "auth",
+]
+
+
+class CapabilityIntent(BaseModel):
+    """Agent-emitted intent ready to be dispatched to a capability endpoint.
+
+    Fields use snake_case (Python convention); `to_capability_request()` rewrites
+    them to camelCase to match the backend envelope.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    capability: CapabilitySlug = Field(
+        ..., description="Target capability slug; controls the URL path."
+    )
+    action: str = Field(
+        ...,
+        min_length=1,
+        description="Action name inside the capability (e.g. 'prepare-swap').",
+    )
+    chain_id: int = Field(..., gt=0, description="EIP-155 chain id.")
+    user_address: str = Field(
+        ..., description="EVM address of the user, 0x-prefixed hex string."
+    )
+    payload: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Action-specific payload (typed by the consumer).",
+    )
+    tenant_id: str = Field(..., min_length=1)
+    trace_id: UUID = Field(..., description="RFC 4122 UUID for distributed tracing.")
+    idempotency_key: Optional[UUID] = Field(
+        default=None,
+        description="Required by state-mutating actions; hash(key+body) caches the response.",
+    )
+
+    @field_validator("user_address")
+    @classmethod
+    def _validate_user_address(cls, value: str) -> str:
+        if not value.startswith("0x") or len(value) != 42:
+            raise ValueError(
+                "user_address must be a 0x-prefixed 42-char EVM address"
+            )
+        try:
+            int(value, 16)
+        except ValueError as err:
+            raise ValueError("user_address must be hex-decodable") from err
+        return value
+
+    @field_validator("action")
+    @classmethod
+    def _validate_action(cls, value: str) -> str:
+        # Lowercase kebab/letters/digits — matches CONVENTIONS.md §6 for action names.
+        if not all(ch.isalnum() or ch in "-_" for ch in value):
+            raise ValueError(
+                "action must contain only alphanumerics, '-' or '_'"
+            )
+        return value
+
+    def to_capability_request(self) -> Dict[str, Any]:
+        """Render the camelCase wire payload for POST /v1/capability/<cap>/<action>.
+
+        The router strips `capability` and `action` — they're already in the URL.
+        """
+        wire: Dict[str, Any] = {
+            "tenantId": self.tenant_id,
+            "traceId": str(self.trace_id),
+            "chainId": self.chain_id,
+            "userAddress": self.user_address,
+            "payload": self.payload,
+        }
+        if self.idempotency_key is not None:
+            wire["idempotencyKey"] = str(self.idempotency_key)
+        return wire
+
+    def endpoint_path(self) -> str:
+        """Return the URL path the dispatcher should POST to."""
+        return f"/v1/capability/{self.capability}/{self.action}"
+
+
+__all__ = ["CapabilityIntent", "CapabilitySlug"]

--- a/new_zico/tests/test_capability_discovery.py
+++ b/new_zico/tests/test_capability_discovery.py
@@ -1,0 +1,205 @@
+"""Tests for src/integrations/panorama_gateway/capability_discovery.py (card #69).
+
+Mocks HTTP via httpx.MockTransport so we exercise the real httpx code path
+without hitting the network. Verifies: discovery unwraps CapabilitySuccessResponse,
+the 30-second cache returns the same payload until force_refresh, and the
+list_healthy_providers projection filters by capability+chain+healthy flag.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+import httpx
+import pytest
+
+from src.integrations.panorama_gateway import capability_discovery as cd
+
+
+BASE_URL = "https://capability.test"
+
+
+def _availability_map_response() -> Dict[str, Any]:
+    return {
+        "status": "success",
+        "data": {
+            "capabilities": [
+                {
+                    "capability": "swap",
+                    "byChain": {
+                        "8453": [
+                            {"provider": "aerodrome", "healthy": True, "latencyP95Ms": 120},
+                            {"provider": "uniswap-trading-api", "healthy": False,
+                             "lastError": "503 from upstream"},
+                        ]
+                    },
+                },
+                {
+                    "capability": "staking",
+                    "byChain": {
+                        "1": [
+                            {"provider": "lido", "healthy": True, "latencyP95Ms": 80}
+                        ]
+                    },
+                },
+            ],
+            "generatedAt": "2026-05-23T20:00:00.000Z",
+            "cacheTtlSeconds": 30,
+        },
+        "traceId": "00000000-0000-4000-8000-000000000001",
+    }
+
+
+class _RequestRecorder:
+    def __init__(self, response_body: Dict[str, Any]) -> None:
+        self.calls: List[httpx.Request] = []
+        self._body = response_body
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self.calls.append(request)
+        return httpx.Response(200, json=self._body)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Reset cache and env before every test so order doesn't leak state."""
+    monkeypatch.setenv("PANORAMA_CAPABILITY_BASE_URL", BASE_URL)
+    cd.clear_cache()
+    yield
+    cd.clear_cache()
+
+
+def _client_with(recorder: _RequestRecorder) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(recorder))
+
+
+# ---------------------------------------------------------------------------
+# Unwrap + cache behavior
+# ---------------------------------------------------------------------------
+
+
+def test_discover_unwraps_capability_success_envelope():
+    recorder = _RequestRecorder(_availability_map_response())
+    with _client_with(recorder) as client:
+        result = cd.discover_capabilities(client=client)
+
+    assert "capabilities" in result
+    assert result["generatedAt"] == "2026-05-23T20:00:00.000Z"
+    assert "status" not in result, "envelope must be stripped"
+    assert len(recorder.calls) == 1
+
+
+def test_cache_hit_does_not_call_http_again():
+    recorder = _RequestRecorder(_availability_map_response())
+    with _client_with(recorder) as client:
+        cd.discover_capabilities(client=client)
+        cd.discover_capabilities(client=client)
+        cd.discover_capabilities(client=client)
+    assert len(recorder.calls) == 1
+
+
+def test_force_refresh_bypasses_cache():
+    recorder = _RequestRecorder(_availability_map_response())
+    with _client_with(recorder) as client:
+        cd.discover_capabilities(client=client)
+        cd.discover_capabilities(client=client, force_refresh=True)
+    assert len(recorder.calls) == 2
+
+
+def test_cache_is_per_chain_id():
+    recorder = _RequestRecorder(_availability_map_response())
+    with _client_with(recorder) as client:
+        cd.discover_capabilities(chain_id=8453, client=client)
+        cd.discover_capabilities(chain_id=1, client=client)
+        cd.discover_capabilities(chain_id=8453, client=client)  # cached
+    assert len(recorder.calls) == 2
+
+
+def test_query_param_includes_chain_id_when_supplied():
+    recorder = _RequestRecorder(_availability_map_response())
+    with _client_with(recorder) as client:
+        cd.discover_capabilities(chain_id=8453, client=client)
+    assert recorder.calls[0].url.params.get("chainId") == "8453"
+
+
+def test_no_query_params_when_chain_id_absent():
+    recorder = _RequestRecorder(_availability_map_response())
+    with _client_with(recorder) as client:
+        cd.discover_capabilities(client=client)
+    assert "chainId" not in recorder.calls[0].url.params
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def test_raises_on_non_200():
+    def transport(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="Service Unavailable")
+
+    with httpx.Client(transport=httpx.MockTransport(transport)) as client:
+        with pytest.raises(cd.DiscoveryFetchError) as exc:
+            cd.discover_capabilities(client=client)
+    assert exc.value.status_code == 503
+
+
+def test_raises_on_invalid_json():
+    def transport(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="not json")
+
+    with httpx.Client(transport=httpx.MockTransport(transport)) as client:
+        with pytest.raises(cd.DiscoveryFetchError):
+            cd.discover_capabilities(client=client)
+
+
+def test_missing_base_url_raises_runtime_error(monkeypatch):
+    monkeypatch.delenv("PANORAMA_CAPABILITY_BASE_URL", raising=False)
+    with pytest.raises(RuntimeError, match="PANORAMA_CAPABILITY_BASE_URL"):
+        cd.discover_capabilities()
+
+
+# ---------------------------------------------------------------------------
+# Projection helper
+# ---------------------------------------------------------------------------
+
+
+def test_list_healthy_providers_filters_unhealthy():
+    recorder = _RequestRecorder(_availability_map_response())
+    with _client_with(recorder) as client:
+        # Prime cache so list_healthy_providers doesn't re-fetch.
+        cd.discover_capabilities(chain_id=8453, client=client)
+    healthy = cd.list_healthy_providers("swap", 8453)
+    assert healthy == ["aerodrome"]
+
+
+def test_list_healthy_providers_returns_empty_on_unknown_capability():
+    recorder = _RequestRecorder(_availability_map_response())
+    with _client_with(recorder) as client:
+        cd.discover_capabilities(chain_id=8453, client=client)
+    assert cd.list_healthy_providers("bridge", 8453) == []
+
+
+# ---------------------------------------------------------------------------
+# LangChain Tool wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_tool_wrapper_returns_discovery_payload(monkeypatch):
+    def fake_discover(chain_id=None, force_refresh=False, client=None):
+        return {"capabilities": [], "generatedAt": "now", "cacheTtlSeconds": 30}
+
+    monkeypatch.setattr(cd, "discover_capabilities", fake_discover)
+    result = cd.discover_capabilities_tool.invoke({"chain_id": 8453})
+    assert result["generatedAt"] == "now"
+
+
+def test_tool_wrapper_swallows_fetch_error_and_returns_empty(monkeypatch):
+    def explode(chain_id=None, force_refresh=False, client=None):
+        raise cd.DiscoveryFetchError("boom", status_code=500)
+
+    monkeypatch.setattr(cd, "discover_capabilities", explode)
+    result = cd.discover_capabilities_tool.invoke({})
+    assert result["capabilities"] == []
+    assert result["error"].startswith("boom") or "500" in result["error"]

--- a/new_zico/tests/test_capability_intent.py
+++ b/new_zico/tests/test_capability_intent.py
@@ -1,0 +1,141 @@
+"""Tests for src/models/capability_intent.py (card #70).
+
+Covers the 5 capabilities the card called out (swap, liquidity, lending,
+staking, automation [aka 'dca' in older zico vocabulary]) plus the validators
+and the camelCase wire renderer.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from src.models.capability_intent import CapabilityIntent
+
+
+TRACE = UUID("11111111-1111-4111-8111-111111111111")
+IDEMP = UUID("22222222-2222-4222-8222-222222222222")
+USER = "0x" + "ab" * 20
+TENANT = "tenant-agent"
+
+
+def _base(**overrides):
+    return {
+        "capability": "swap",
+        "action": "prepare-swap",
+        "chain_id": 8453,
+        "user_address": USER,
+        "payload": {"tokenIn": "0xeeee", "amountIn": "1000000000000000000"},
+        "tenant_id": TENANT,
+        "trace_id": TRACE,
+        **overrides,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path — every capability the card called out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "capability,action,payload",
+    [
+        ("swap", "prepare-swap", {"tokenIn": "0xeeee", "amountIn": "1"}),
+        ("liquidity", "prepare-add", {"poolId": "0xpool", "amountA": "1"}),
+        ("lending", "prepare-borrow", {"asset": "USDC", "amount": "100"}),
+        ("staking", "prepare-stake", {"amount": "1000000000000000000"}),
+        # 'dca' from older zico vocabulary maps to the 'automation' slug
+        # in shared/capability/provider.types.ts (CAPABILITY_SLUGS).
+        ("automation", "schedule-dca", {"frequency": "weekly", "amount": "100"}),
+    ],
+)
+def test_intent_round_trip_per_capability(capability, action, payload):
+    intent = CapabilityIntent(**_base(capability=capability, action=action, payload=payload))
+    assert intent.capability == capability
+    assert intent.action == action
+
+    wire = intent.to_capability_request()
+    assert wire == {
+        "tenantId": TENANT,
+        "traceId": str(TRACE),
+        "chainId": 8453,
+        "userAddress": USER,
+        "payload": payload,
+    }
+    assert intent.endpoint_path() == f"/v1/capability/{capability}/{action}"
+
+
+def test_idempotency_key_passes_through_when_set():
+    intent = CapabilityIntent(**_base(idempotency_key=IDEMP))
+    wire = intent.to_capability_request()
+    assert wire["idempotencyKey"] == str(IDEMP)
+
+
+def test_idempotency_key_omitted_when_unset():
+    intent = CapabilityIntent(**_base())
+    assert "idempotencyKey" not in intent.to_capability_request()
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_unknown_capability_slug():
+    with pytest.raises(ValidationError):
+        CapabilityIntent(**_base(capability="degen"))
+
+
+def test_rejects_non_evm_address():
+    with pytest.raises(ValidationError) as exc:
+        CapabilityIntent(**_base(user_address="not-an-address"))
+    assert "user_address" in str(exc.value)
+
+
+def test_rejects_address_wrong_length():
+    with pytest.raises(ValidationError):
+        CapabilityIntent(**_base(user_address="0xabc"))
+
+
+def test_rejects_non_hex_address():
+    with pytest.raises(ValidationError):
+        CapabilityIntent(**_base(user_address="0x" + "zz" * 20))
+
+
+def test_rejects_non_positive_chain_id():
+    with pytest.raises(ValidationError):
+        CapabilityIntent(**_base(chain_id=0))
+
+
+def test_rejects_action_with_invalid_chars():
+    with pytest.raises(ValidationError):
+        CapabilityIntent(**_base(action="prepare swap"))
+
+
+def test_rejects_empty_tenant_id():
+    with pytest.raises(ValidationError):
+        CapabilityIntent(**_base(tenant_id=""))
+
+
+def test_rejects_extra_unknown_field():
+    # model_config extra='forbid' — agents must not smuggle protocol names through.
+    with pytest.raises(ValidationError):
+        CapabilityIntent(**_base(provider="aerodrome"))
+
+
+def test_intent_is_immutable():
+    intent = CapabilityIntent(**_base())
+    with pytest.raises(ValidationError):
+        intent.capability = "lending"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Trace id flexibility
+# ---------------------------------------------------------------------------
+
+
+def test_accepts_uuid_as_string():
+    intent = CapabilityIntent(**_base(trace_id=str(uuid4())))
+    assert isinstance(intent.trace_id, UUID)


### PR DESCRIPTION
## Summary

First Rizzi-track Zico migration to the new `@panorama/capability` substrate. Three independent cards bundled because they form one minimum viable contract — schema for what agents emit, tool for what agents look up, doc for the rules they must follow.

- **#70** — `CapabilityIntent` Pydantic v2 schema (`new_zico/src/models/capability_intent.py`). Maps 1:1 to Hugo's `CapabilityRequest<T>` envelope with two extra fields (`capability` + `action`) that identify the target endpoint. `to_capability_request()` strips those and emits the camelCase wire payload. `extra=\"forbid\" + frozen=True` so agents cannot smuggle `provider=\"aerodrome\"` or mutate the intent post-emission.
- **#69** — Capability discovery tool (`new_zico/src/integrations/panorama_gateway/capability_discovery.py`). httpx call to `GET /v1/capability/_discovery` (Hugo card #207), unwraps `CapabilitySuccessResponse`, 30-second per-`chain_id` thread-safe cache (honors `cacheTtlSeconds` from the BE), `list_healthy_providers()` projection, and a `@tool`-decorated LangChain wrapper any agent can register. Graceful degradation: on `DiscoveryFetchError`, the tool returns `{ capabilities: [], error }` so the agent can tell the user \"nothing available\" instead of hallucinating providers.
- **#66** — `new_zico/docs/agent-capability-contract.md` documenting the NL→intent pipeline, the no-protocol-names hard rule, the `ErrorCategory` → human-friendly message table, and a roteiro for new agents. Linked from `SPRINT_KICKOFF.md` §15.

Closes Panorama-Block/zico_agents#66
Closes Panorama-Block/zico_agents#69
Closes Panorama-Block/zico_agents#70

## Diff stats

- 3 atomic commits (`3f421e95` #70, `91de58d0` #69, `fd32ca63` #66)
- 5 files added, **+800** LOC (code + tests + doc)

## Test plan

- [x] `pytest tests/test_capability_intent.py` — **17/17 pass** (covers 5 capabilities: swap, liquidity, lending, staking, automation; all validators)
- [x] `pytest tests/test_capability_discovery.py` — **13/13 pass** via `httpx.MockTransport` (envelope unwrap, cache hit/miss per chain, force_refresh, HTTP errors, invalid JSON, projection helper, Tool wrapper)
- [x] Full suite regression check — **43/43 pass** for non-network tests (skipped `test_strategy_live_data.py`, `test_chat_storage_contract.py`, `test_gateway_storage_shared_state.py` which require env vars / live infra and were already in that state on develop)
- [x] Pydantic V2 deprecation warnings observed in `chatMessage.py` are **pre-existing** on develop — out of scope here

## Setup notes

- New env var: `PANORAMA_CAPABILITY_BASE_URL` — base URL where the BE capability layer is reachable (e.g. `https://api.panorama.test` or local `http://localhost:3003` during dev). Add to `.env.example` after merge.
- `CapabilitySlug` Literal must stay aligned with `CAPABILITY_SLUGS` in `panorama-block-backend/shared/capability/provider.types.ts` — update both sides together when adding a new capability (called out in the schema docstring).

## What this PR does NOT do

- No agent prompts are touched yet — those land in #67 (liquidity) and #68 (strategy/routing), gated on #66.
- No contract tests across agents yet — #71 lands after #67/#68 merge.
- No BE call site changes — every existing agent keeps its current tools; this PR just adds new building blocks.

## Cross-team note

cc @noymaxx — the discovery tool consumes the response shape your handler emits in card #207. Test fixture uses the literal `CapabilitySuccessResponse` envelope (`{ status: \"success\", data: AvailabilityMap, traceId }`); if the wire shape drifts, this fixture is where the agent-side will catch it first.

Companion PRs in panorama-block-backend: #281 (swap), #282 (liquidity).